### PR TITLE
Fix: Prevent re-modification of already modified links

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -57,9 +57,11 @@ async def handle_message(update: Update, context: CallbackContext):
     # Handle domain modifications
     modified_links = []
     for link in message_text.split():
-        if any(link.startswith(modified_domain) for modified_domain in domain_modifications.values()):
+        # Skip links that are already modified, with or without "https://"
+        if any(modified_domain in link for modified_domain in domain_modifications.values()):
             continue
-        
+
+        # Modify unmodified links
         for domain, modified_domain in domain_modifications.items():
             if domain in link:
                 modified_links.append(link.replace(domain, modified_domain))


### PR DESCRIPTION
Fixes #9 Prevent re-modification of links

This PR addresses the issue where links that are already modified (with or without the "https://") were being re-modified, causing incorrect behavior.

Changes:
Updated the link modification logic to check if a link already starts with the modified domain (with or without "https://").
Links that have already been modified will now be skipped, preventing unnecessary changes.
This should ensure that links are only modified once and the bot behaves as expected.