### PR TITLE
fix: standardize error logging and eliminate silent exception swallowing

### DIFF
--- a/modules/diagnostics.py
+++ b/modules/diagnostics.py
@@ -170,7 +170,7 @@ async def monitor_api_health() -> None:
                 if api_health["consecutive_failures"] >= 3:
                     error_logger.error(f"Multiple consecutive API failures detected. Running diagnostics...")
                     diagnosis = await run_api_diagnostics(Config.OPENROUTER_BASE_URL)
-                    error_logger.error(f"Diagnosis result: {diagnosis}")
+                    error_logger.warning(f"Diagnosis result: {diagnosis}")
 
         except Exception as e:
             error_logger.error(f"Error in API health monitoring: {e}", exc_info=True)

--- a/modules/diagnostics.py
+++ b/modules/diagnostics.py
@@ -125,17 +125,17 @@ async def run_api_diagnostics(api_url: str) -> Dict[str, Any]:
     
     # Generate recommendation based on results
     if not results["internet_connectivity"]:
-        general_logger.error("DIAGNOSIS: No internet connectivity detected. Check network connection.")
+        error_logger.error("DIAGNOSIS: No internet connectivity detected. Check network connection.")
         results["diagnosis"] = "No internet connectivity"
         return results
-    
+
     if any(result == "Failed to resolve" for result in results["dns_resolution"].values()):
-        general_logger.error("DIAGNOSIS: DNS resolution issues detected. Check DNS configuration.")
+        error_logger.error("DIAGNOSIS: DNS resolution issues detected. Check DNS configuration.")
         results["diagnosis"] = "DNS resolution issues"
         return results
-    
+
     if not results["target_connection"]:
-        general_logger.error(f"DIAGNOSIS: Cannot connect to API endpoint {api_url}. Check if the URL is correct and the service is available.")
+        error_logger.error(f"DIAGNOSIS: Cannot connect to API endpoint {api_url}. Check if the URL is correct and the service is available.")
         results["diagnosis"] = "API endpoint unreachable"
         return results
     
@@ -168,12 +168,12 @@ async def monitor_api_health() -> None:
                 
                 # If multiple consecutive failures, run diagnostics
                 if api_health["consecutive_failures"] >= 3:
-                    general_logger.error(f"Multiple consecutive API failures detected. Running diagnostics...")
+                    error_logger.error(f"Multiple consecutive API failures detected. Running diagnostics...")
                     diagnosis = await run_api_diagnostics(Config.OPENROUTER_BASE_URL)
-                    general_logger.error(f"Diagnosis result: {diagnosis}")
-        
+                    error_logger.error(f"Diagnosis result: {diagnosis}")
+
         except Exception as e:
-            general_logger.error(f"Error in API health monitoring: {e}")
+            error_logger.error(f"Error in API health monitoring: {e}", exc_info=True)
             
         # Wait before next check (5 minutes)
         await asyncio.sleep(300)

--- a/modules/diagnostics_command.py
+++ b/modules/diagnostics_command.py
@@ -291,7 +291,7 @@ class SystemDiagnosticsCommand:
                     try:
                         dt = datetime.fromisoformat(timestamp)
                         time_str = dt.strftime("%H:%M %d.%m")
-                    except:
+                    except (ValueError, TypeError):
                         time_str = timestamp[:16]
                 else:
                     time_str = "Unknown"
@@ -411,7 +411,7 @@ class SystemDiagnosticsCommand:
                     try:
                         dt = datetime.fromisoformat(timestamp)
                         time_str = dt.strftime("%H:%M")
-                    except:
+                    except (ValueError, TypeError):
                         time_str = "??:??"
                 else:
                     time_str = "??:??"

--- a/modules/enhanced_flares_command.py
+++ b/modules/enhanced_flares_command.py
@@ -351,9 +351,9 @@ class EnhancedFlaresCommand:
             if status_msg:
                 try:
                     await status_msg.delete()
-                except:
-                    pass
-            
+                except Exception:
+                    pass  # cleanup
+
             # Send user-friendly error message
             user_error_message = self._get_user_friendly_error_message(e)
             

--- a/modules/gpt.py
+++ b/modules/gpt.py
@@ -137,7 +137,7 @@ class OpenAIAsyncClient:
                             general_logger.warning(f"API connection failed (attempt {attempt + 1}/{MAX_RETRIES}): {type(e).__name__}. Retrying in {wait_time}s...")
                             await asyncio.sleep(wait_time)
                         else:
-                            general_logger.error(f"API connection failed after {MAX_RETRIES} attempts: {type(e).__name__}")
+                            error_logger.error(f"API connection failed after {MAX_RETRIES} attempts: {type(e).__name__}", exc_info=True)
                             raise
                 raise last_exception  # type: ignore
 
@@ -469,7 +469,7 @@ async def verify_api_key() -> bool:
         bool: Whether the API key is valid
     """
     if not Config.OPENROUTER_API_KEY or not Config.OPENROUTER_API_KEY.startswith("sk-"):
-        general_logger.error("Invalid or missing API key")
+        error_logger.error("Invalid or missing API key")
         return False
     return True
 
@@ -1203,8 +1203,8 @@ async def analyze_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                     await update.message.reply_text(
                         "❌ Аналіз завершено, але виникла помилка при відправці результату."
                     )
-            except:
-                pass  # If even this fails, we can't do much more
+            except Exception as fallback_error:
+                error_logger.warning(f"Failed to send fallback error message: {fallback_error}")
 
     except Exception as e:
         # Comprehensive error handling for any unexpected errors

--- a/modules/handlers/message_handlers.py
+++ b/modules/handlers/message_handlers.py
@@ -373,7 +373,6 @@ async def handle_location(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         }, exc_info=True)
         if update.message:
             await update.message.reply_text("❌ Error occurred. This has been reported to the developer.")
-        await update.message.reply_text("📍 Location received!")
 
 
 async def handle_voice_or_video_note(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/modules/handlers/message_handlers.py
+++ b/modules/handlers/message_handlers.py
@@ -102,8 +102,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             )
             ban_words = cb_overrides.get("ban_words", [])
             ban_symbols = cb_overrides.get("ban_symbols", [])
-        except Exception:
-            pass
+        except Exception as cfg_err:
+            error_logger.warning(f"Failed to load chat behavior config: {cfg_err}", exc_info=True)
     if should_restrict_user(message_text, ban_words=ban_words, ban_symbols=ban_symbols):
         await restrict_user(update, context)
         return
@@ -370,7 +370,7 @@ async def handle_location(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             'chat_id': update.effective_chat.id if update.effective_chat else 'N/A',
             'username': update.effective_user.username if update.effective_user else 'N/A',
             'chat_title': update.effective_chat.title if update.effective_chat else 'N/A'
-        })
+        }, exc_info=True)
         if update.message:
             await update.message.reply_text("❌ Error occurred. This has been reported to the developer.")
         await update.message.reply_text("📍 Location received!")

--- a/modules/handlers/random_commands.py
+++ b/modules/handlers/random_commands.py
@@ -107,5 +107,6 @@ async def is_admin(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     try:
         member = await context.bot.get_chat_member(chat.id, user.id)
         return member.status in {"administrator", "creator"}
-    except Exception:
+    except Exception as e:
+        logger.warning(f"Failed to check admin status for user {user.id} in chat {chat.id}: {e}")
         return False

--- a/modules/handlers/reaction_update_handler.py
+++ b/modules/handlers/reaction_update_handler.py
@@ -11,7 +11,7 @@ import os
 from telegram import Update, ReactionTypeEmoji
 from telegram.ext import ContextTypes
 
-from modules.logger import general_logger
+from modules.logger import general_logger, error_logger
 
 
 async def handle_reaction_update(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -55,7 +55,7 @@ async def _handle_shorts_download(context, chat_id, message_id, shorts_url, user
 
     video_downloader = context.bot_data.get("video_downloader")
     if not video_downloader:
-        general_logger.error("Video downloader not available for ⚡ reaction")
+        error_logger.error("Video downloader not available for ⚡ reaction")
         return
 
     processing_msg = await context.bot.send_message(
@@ -79,8 +79,8 @@ async def _handle_shorts_download(context, chat_id, message_id, shorts_url, user
 
         try:
             await processing_msg.delete()
-        except Exception:
-            pass
+        except Exception as del_err:
+            error_logger.warning(f"Failed to delete processing message: {del_err}")
 
         special_chars = [
             "_", "*", "[", "]", "(", ")", "~", "`", ">",
@@ -115,15 +115,15 @@ async def _handle_shorts_download(context, chat_id, message_id, shorts_url, user
         general_logger.info(f"Successfully sent Shorts via ⚡ reaction: {title}")
 
     except Exception as e:
-        general_logger.error(f"Error in ⚡ shorts download: {e}", exc_info=True)
+        error_logger.error(f"Error in ⚡ shorts download: {e}", exc_info=True)
         try:
             await processing_msg.edit_text(f"Error downloading Shorts: {str(e)[:100]}")
-        except Exception:
-            pass
+        except Exception as edit_err:
+            error_logger.warning(f"Failed to edit processing message after error: {edit_err}")
 
     finally:
         if filename and os.path.exists(filename):
             try:
                 os.remove(filename)
             except Exception:
-                pass
+                pass  # cleanup

--- a/modules/handlers/reaction_update_handler.py
+++ b/modules/handlers/reaction_update_handler.py
@@ -80,7 +80,7 @@ async def _handle_shorts_download(context, chat_id, message_id, shorts_url, user
         try:
             await processing_msg.delete()
         except Exception as del_err:
-            error_logger.warning(f"Failed to delete processing message: {del_err}")
+            general_logger.warning(f"Failed to delete processing message: {del_err}")
 
         special_chars = [
             "_", "*", "[", "]", "(", ")", "~", "`", ">",
@@ -119,7 +119,7 @@ async def _handle_shorts_download(context, chat_id, message_id, shorts_url, user
         try:
             await processing_msg.edit_text(f"Error downloading Shorts: {str(e)[:100]}")
         except Exception as edit_err:
-            error_logger.warning(f"Failed to edit processing message after error: {edit_err}")
+            general_logger.warning(f"Failed to edit processing message after error: {edit_err}")
 
     finally:
         if filename and os.path.exists(filename):

--- a/modules/handlers/speech_commands.py
+++ b/modules/handlers/speech_commands.py
@@ -111,5 +111,6 @@ async def is_admin(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     try:
         member = await context.bot.get_chat_member(chat.id, user.id)
         return member.status in {"administrator", "creator"}
-    except Exception:
+    except Exception as e:
+        logger.warning(f"Failed to check admin status for user {user.id} in chat {chat.id}: {e}")
         return False

--- a/modules/message_handler.py
+++ b/modules/message_handler.py
@@ -101,7 +101,7 @@ async def handle_gpt_reply(
             gpt_context_message_ids=context_message_ids
         )
     except Exception as e:
-        print(f"Error storing GPT reply: {e}")
+        error_logger.error(f"Error storing GPT reply: {e}", exc_info=True)
 
 def setup_message_handlers(application: Application[Any, Any, Any, Any, Any, Any]) -> None:
     """

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1288,9 +1288,9 @@ async def screenshot_command(update: Update, context: CallbackContext[Any, Any, 
         if status_msg:
             try:
                 await status_msg.delete()
-            except:
-                pass
-        
+            except Exception:
+                pass  # cleanup
+
         # Send error message to user
         error_msg = (
             "❌ Не вдалося завантажити дані про сонячну активність.\n"
@@ -1304,9 +1304,9 @@ async def screenshot_command(update: Update, context: CallbackContext[Any, Any, 
         if status_msg:
             try:
                 await status_msg.delete()
-            except:
-                pass
-        
+            except Exception:
+                pass  # cleanup
+
         # Clean up screenshot file if it exists
         if 'screenshot_path' in locals() and screenshot_path and os.path.exists(screenshot_path):
             try:

--- a/modules/video_downloader.py
+++ b/modules/video_downloader.py
@@ -695,8 +695,8 @@ class VideoDownloader:
                               os.path.getsize(output_path) > 0)
                     if not success:
                         os.remove(output_path)
-                except:
-                    pass
+                except Exception:
+                    pass  # cleanup
 
     async def download_youtube_music(self, url: str) -> Tuple[Optional[str], Optional[str]]:
         """Download audio from YouTube Music as MP3 using multiple strategies."""
@@ -1040,8 +1040,8 @@ class VideoDownloader:
                 # Cleanup local file
                 try:
                     os.remove(filename)
-                except:
-                    pass
+                except Exception:
+                    pass  # cleanup
             else:
                 await self._send_inline_error(query, "Download failed")
 
@@ -1109,8 +1109,8 @@ class VideoDownloader:
                 # Cleanup local file
                 try:
                     os.remove(filename)
-                except:
-                    pass
+                except Exception:
+                    pass  # cleanup
             else:
                 await self._send_inline_error(query, "Download failed")
 
@@ -1228,8 +1228,8 @@ class VideoDownloader:
                     # Only remove if download failed
                     if not (process.returncode == 0 and os.path.getsize(output_path) > 0):
                         os.remove(output_path)
-                except:
-                    pass
+                except Exception:
+                    pass  # cleanup
 
     async def _get_video_title(self, url: str) -> str:
         try:
@@ -1897,8 +1897,8 @@ class VideoDownloader:
                         if os.path.exists(output_template):
                             try:
                                 os.remove(output_template)
-                            except:
-                                pass
+                            except Exception:
+                                pass  # cleanup
                         
                         # If this is not the last strategy, continue to next
                         if i < len(strategies) - 1:
@@ -1913,15 +1913,15 @@ class VideoDownloader:
                         try:
                             process.kill()
                             await process.wait()
-                        except:
-                            pass
+                        except Exception:
+                            pass  # cleanup
                     
                     # Clean up any partial files
                     if os.path.exists(output_template):
                         try:
                             os.remove(output_template)
-                        except:
-                            pass
+                        except Exception:
+                            pass  # cleanup
                     
                     # If this is not the last strategy, continue to next
                     if i < len(strategies) - 1:
@@ -1959,8 +1959,8 @@ class VideoDownloader:
                 try:
                     process.kill()
                     await process.wait()
-                except:
-                    pass
+                except Exception:
+                    pass  # cleanup
 
         return None, None
 

--- a/modules/weather.py
+++ b/modules/weather.py
@@ -113,7 +113,7 @@ class WeatherAPI:
         if self.api_key and len(self.api_key) > 4:
             general_logger.info(f"WeatherAPI initialized with key ending in '...{self.api_key[-4:]}'")
         else:
-            general_logger.error("WeatherAPI initialized WITHOUT a valid API key.")
+            error_logger.error("WeatherAPI initialized WITHOUT a valid API key.")
         self.client = httpx.AsyncClient()
     
     def _is_cache_valid(self, city: str) -> bool:


### PR DESCRIPTION
## Summary

- **Route real errors to the Telegram error channel:** Replace `general_logger.error()` with `error_logger.error()` in `gpt.py`, `diagnostics.py`, `reaction_update_handler.py`, and `weather.py` so these errors are forwarded to the error channel rather than staying in local logs only.
- **Add missing tracebacks:** Add `exc_info=True` to `error_logger` calls that were missing it (`diagnostics.py` health monitor, `gpt.py` connection failure, `message_handlers.py` location handler, `message_handler.py` GPT reply storage).
- **Replace `print()` with structured logging:** `message_handler.py` was using `print()` for a GPT reply storage error; replaced with `error_logger.error(..., exc_info=True)`.
- **Eliminate silent `except: pass` blocks:** Previously silent swallows in `message_handlers.py` (chat behavior config load) and `reaction_update_handler.py` (message delete/edit failures) now log a warning with context.
- **Narrow bare `except:` to `except Exception:`:** All file/process cleanup blocks in `video_downloader.py`, `utils.py`, `enhanced_flares_command.py`, and `reaction_update_handler.py` are narrowed to `except Exception:` with `# cleanup` comments to document intent and avoid accidentally swallowing `KeyboardInterrupt`/`SystemExit`.
- **Narrow timestamp parse fallbacks:** Two bare `except:` blocks in `diagnostics_command.py` narrowed to `except (ValueError, TypeError):` since only those errors are expected from `datetime.fromisoformat()`.
- **Improve silent admin-check failure logging:** `random_commands.py` and `speech_commands.py` now log a warning when `get_chat_member()` fails instead of silently returning `False`.
- **Improve fallback error path in `gpt.py`:** The bare `except: pass` in `analyze_command` that swallowed failures to send a fallback error message is now `except Exception as fallback_error:` with a `error_logger.warning()`.

## Test plan

- [ ] Verify bot starts without import errors across all changed modules
- [ ] Trigger a GPT API failure (e.g. bad key) and confirm the error appears in the Telegram error channel
- [ ] Trigger a weather API init with no key and confirm it appears in the Telegram error channel
- [ ] Confirm that file cleanup paths (video downloader, screenshot command) still work correctly and don't raise unexpected exceptions
- [ ] Run diagnostics command and confirm timestamp parsing still works for valid ISO timestamps